### PR TITLE
Fix Windows build repository access issues

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
+          cache-read-only: false
 
       - name: Compute version
         id: version
@@ -38,7 +41,22 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Build fat jar
-        run: gradle -p Code :desktop:distJar
+        shell: bash
+        run: |
+          cd Code
+          for attempt in 1 2 3; do
+            echo "Build attempt $attempt/3..."
+            if gradle :desktop:distJar --refresh-dependencies; then
+              echo "Build succeeded on attempt $attempt"
+              exit 0
+            fi
+            if [ $attempt -lt 3 ]; then
+              echo "Build failed, waiting before retry..."
+              sleep 30
+            fi
+          done
+          echo "Build failed after 3 attempts"
+          exit 1
 
       - name: Package app image (Linux/macOS)
         if: runner.os != 'Windows'

--- a/Code/gradle.properties
+++ b/Code/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx512m
 org.gradle.configureondemand=true
+
+# Repository and network timeout settings for CI environments (especially Windows)
+org.gradle.internal.http.socketTimeout=120000
+org.gradle.internal.http.connectionTimeout=120000

--- a/Code/init.gradle
+++ b/Code/init.gradle
@@ -1,0 +1,51 @@
+// Gradle init script to configure repository mirrors for improved CI reliability
+// Placed in Code/init.gradle and automatically applied by Gradle
+
+allprojects {
+    repositories {
+        all { ArtifactRepository repo ->
+            if (repo instanceof MavenArtifactRepository) {
+                def url = repo.url.toString()
+                if (url.contains('repo.maven.apache.org') || url.contains('repo1.maven.org')) {
+                    println("Removing potentially blocked repository: $url")
+                    remove repo
+                }
+            }
+        }
+        
+        // Primary Maven Central mirror with good global coverage
+        maven {
+            url "https://repo1.maven.org/maven2/"
+            metadataSources {
+                mavenPom()
+                artifact()
+            }
+        }
+        
+        // Fallback to Sonatype releases
+        maven {
+            url "https://oss.sonatype.org/content/repositories/releases/"
+            metadataSources {
+                mavenPom()
+                artifact()
+            }
+        }
+        
+        // JitPack for GitHub-based dependencies
+        maven {
+            url "https://jitpack.io"
+            metadataSources {
+                mavenPom()
+                artifact()
+            }
+        }
+        
+        // Maven Central via different path as fallback
+        mavenCentral {
+            metadataSources {
+                mavenPom()
+                artifact()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Windows CI runner was receiving 403 Forbidden errors from Maven repositories, failing the build at dependency resolution.

## Solution
- Added network timeout configuration in gradle.properties
- Created init.gradle with repository mirror configuration
- Added retry logic with 30-second backoff to workflow (up to 3 attempts)
- Updated Gradle setup to ensure caching is enabled

## Changes
- Code/gradle.properties: Extended socket and connection timeouts
- Code/init.gradle: Repository mirror configuration for robust CI builds
- .github/workflows/release-on-main.yml: Retry logic on build fat jar step