### PR TITLE
Rename build outputs to Dragon's Dive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ hs_err_pid*
 /Code/desktop/build
 /Code/.idea
 /Code/core/build
+.vscode/settings.json
+Code/build/

--- a/Code/build.gradle
+++ b/Code/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     apply plugin: "java"
     version = '1.0.0'
     ext {
-        appName = "EpigonProto"
+        appName = "Dragon's Dive"
         squidlibVersion = '3.0.6'
         jacksonVersion = '2.8.6'
         gdxVersion = '1.11.0'

--- a/Code/core/src/main/java/squidpony/epigon/Prefs.java
+++ b/Code/core/src/main/java/squidpony/epigon/Prefs.java
@@ -9,7 +9,7 @@ public class Prefs {
 
     static private int screenWidth = Dive.totalPixelWidth();
     static private int screenHeight = Dive.totalPixelHeight();
-    static private String title = "Dragon Dive - Fall To Riches";
+    static private String title = "Dragon's Dive - Fall To Riches";
     static private String prefKey = "DragonDive";
     static private boolean debug = true;
 

--- a/Code/desktop/build.gradle
+++ b/Code/desktop/build.gradle
@@ -23,6 +23,8 @@ ext {
     assetsDir = file('assets')
 }
 
+def legacyAppName = 'Epigon'
+
 tasks.named('run', JavaExec) {
     workingDir = assetsDir
     standardInput = System.in
@@ -40,8 +42,13 @@ tasks.register('debug', JavaExec) {
 
 tasks.register('distJar', Jar) {
     dependsOn tasks.named('classes')
-    archiveFileName = "Epigon-${project.version}.jar"
+    archiveFileName = "${appName}-${project.version}.jar"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    doFirst {
+        delete(fileTree("$buildDir/libs") {
+            include "${legacyAppName}-*.jar"
+        })
+    }
     manifest {
         attributes 'Main-Class': application.mainClass.get()
     }
@@ -63,12 +70,14 @@ tasks.register('localExecutable', Exec) {
 
     doFirst {
         localReleaseDir.get().asFile.mkdirs()
-        delete(new File(localReleaseDir.get().asFile, 'Epigon'))
-        delete(new File(localReleaseDir.get().asFile, 'Epigon.app'))
-        def jarName = "Epigon-${project.version}.jar"
+        delete(new File(localReleaseDir.get().asFile, appName))
+        delete(new File(localReleaseDir.get().asFile, "${appName}.app"))
+        delete(new File(localReleaseDir.get().asFile, legacyAppName))
+        delete(new File(localReleaseDir.get().asFile, "${legacyAppName}.app"))
+        def jarName = "${appName}-${project.version}.jar"
         commandLine 'jpackage',
             '--type', 'app-image',
-            '--name', 'Epigon',
+            '--name', appName,
             '--input', file("$buildDir/libs").absolutePath,
             '--dest', localReleaseDir.get().asFile.absolutePath,
             '--main-jar', jarName,
@@ -81,10 +90,15 @@ tasks.register('localExecutableZip', Zip) {
     group = 'distribution'
     description = 'Creates a zip archive of the local native app-image executable.'
     destinationDirectory = layout.buildDirectory.dir('release').get().asFile
-    archiveFileName = "Epigon-${project.version}-${System.getProperty('os.name').replaceAll('\\\\s+', '')}.zip"
+    archiveFileName = "${appName}-${project.version}-${System.getProperty('os.name').replaceAll('\\s+', '')}.zip"
+    doFirst {
+        delete(fileTree(localReleaseDir) {
+            include "${legacyAppName}-*.zip"
+        })
+    }
     from(localReleaseDir) {
-        include 'Epigon/**'
-        include 'Epigon.app/**'
+        include "${appName}/**"
+        include "${appName}.app/**"
     }
 }
 


### PR DESCRIPTION
## Summary
- rename the shared application name to Dragon's Dive
- update desktop jar, app-image, and zip naming to use the shared app name
- clean legacy Epigon build outputs and correct the window title text

## Validation
- ./gradlew :desktop:distJar
- ./gradlew :desktop:localExecutableZip